### PR TITLE
アカウント登録画面のデザインを整形する

### DIFF
--- a/lib/account_list.dart
+++ b/lib/account_list.dart
@@ -95,14 +95,15 @@ class _AccountListState extends State<AccountList> {
                     subtitle: Text(account.accountId),
                     onTap: () async {
                       AccountMst accountMst = await Navigator.of(context).push(
-                        MaterialPageRoute(builder: (context) {
-                          // 遷移先の画面としてリスト追加画面を指定
-                          return AccountDetail(account);
-                        }),
-                      ) ?? AccountMst.empty();
-                       String accountId = accountMst.accountId;
-                       String password = accountMst.password;
-                       String title = accountMst.title;
+                            MaterialPageRoute(builder: (context) {
+                              // 遷移先の画面としてリスト追加画面を指定
+                              return AccountDetail(account);
+                            }),
+                          ) ??
+                          AccountMst.empty();
+                      String accountId = accountMst.accountId;
+                      String password = accountMst.password;
+                      String title = accountMst.title;
                       if (!(accountId == '' && password == '' && title == '')) {
                         setState(() {
                           accountList[index] = accountMst;
@@ -157,15 +158,15 @@ class _AccountListState extends State<AccountList> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
-           final newAccount = await showModalBottomSheet<AccountMst>(
-               context: context,
-               backgroundColor: Colors.transparent,
-               isScrollControlled: true,
-               enableDrag: true,
-               barrierColor: Colors.black.withOpacity(0.5),
-               builder: (context) {
-                 return const AccountRegist();
-               });
+          final newAccount = await showModalBottomSheet<AccountMst>(
+              context: context,
+              backgroundColor: Colors.transparent,
+              isScrollControlled: true,
+              enableDrag: true,
+              barrierColor: Colors.black.withOpacity(0.5),
+              builder: (context) {
+                return const AccountRegist();
+              });
           if (newAccount != null) {
             setState(() {
               accountList.add(newAccount);

--- a/lib/account_list.dart
+++ b/lib/account_list.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:passwordmanagerapp/account_regist.dart';
 import 'package:passwordmanagerapp/account_mst.dart';
 import 'package:flutter/services.dart';
-
 import 'account_detail.dart';
 
 // リスト一覧画面用Widget
@@ -158,13 +157,15 @@ class _AccountListState extends State<AccountList> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
-          // "push"で新規画面に遷移
-          final newAccount = await Navigator.of(context).push(
-            MaterialPageRoute(builder: (context) {
-              // 遷移先の画面としてリスト追加画面を指定
-              return const AccountRegist();
-            }),
-          );
+           final newAccount = await showModalBottomSheet<AccountMst>(
+               context: context,
+               backgroundColor: Colors.transparent,
+               isScrollControlled: true,
+               enableDrag: true,
+               barrierColor: Colors.black.withOpacity(0.5),
+               builder: (context) {
+                 return const AccountRegist();
+               });
           if (newAccount != null) {
             setState(() {
               accountList.add(newAccount);

--- a/lib/account_mst.dart
+++ b/lib/account_mst.dart
@@ -8,5 +8,4 @@ class AccountMst {
       : accountId = '',
         password = '',
         title = '';
-
 }

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -65,24 +65,37 @@ class _AccountRegistState extends State<AccountRegist> {
             child: SingleChildScrollView(
               child: Column(
                 children: <Widget>[
-                  Container(
-                    color: customSwatch[50],
-                    child: TextField(
-                      decoration: const InputDecoration(
-                        border: InputBorder.none,
-                        label: Center(
-                          child: Text(
-                            'パスワードのタイトル',
-                            style: TextStyle(color: Colors.grey),
+                  Row(
+                    children: <Widget>[
+                      Flexible(
+                        child: Container(
+                          color: customSwatch[50],
+                          child: TextField(
+                            decoration: const InputDecoration(
+                              border: InputBorder.none,
+                              label: Center(
+                                child: Text(
+                                  'パスワードのタイトル',
+                                  style: TextStyle(color: Colors.grey),
+                                ),
+                              ),
+                            ),
+                            // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                            onChanged: (String value) {
+                              // データを変更
+                              account.title = value;
+                            },
                           ),
                         ),
                       ),
-                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                      onChanged: (String value) {
-                        // データを変更
-                        account.title = value;
-                      },
-                    ),
+                      const SizedBox(width: 1),
+                      SizedBox(
+                        width: 50,
+                        height: 50,
+                        child: Image.network(
+                          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBVpMw6hVH4re8VfuG2KpZPDd2snPAxzSpUOlFSNqYEw&s'),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 1),
                   Container(

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -94,7 +94,8 @@ class _AccountRegistState extends State<AccountRegist> {
                         width: 50,
                         height: 50,
                         child: Image.network(
-                          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBVpMw6hVH4re8VfuG2KpZPDd2snPAxzSpUOlFSNqYEw&s'),
+                          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTBVpMw6hVH4re8VfuG2KpZPDd2snPAxzSpUOlFSNqYEw&s',
+                        ),
                       ),
                     ],
                   ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -222,6 +222,51 @@ class _AccountRegistState extends State<AccountRegist> {
                       onChanged: (String value) {},
                     ),
                   ),
+                  const SizedBox(
+                    height: 1,
+                  ),
+                  Row(
+                    children: <Widget>[
+                      Container(
+                        color: customSwatch[50],
+                        child: SizedBox(
+                          width: 100,
+                          height: 100,
+                          child: IconButton(
+                            icon: const Icon(
+                              Icons.camera_alt_outlined,
+                              size: 60,
+                              color: customSwatch,
+                            ),
+                            onPressed: () {},
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 1),
+                      Flexible(
+                        child: Container(
+                          height: 100,
+                          color: customSwatch[50],
+                          child: TextField(
+                            keyboardType: TextInputType.multiline,
+                            maxLines: null,
+                            decoration: const InputDecoration(
+                              border: InputBorder.none,
+                              label: Center(
+                                child: Text(
+                                  'メモを入力',
+                                  style: TextStyle(
+                                    color: Colors.grey,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            onChanged: (String value) {},
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -19,7 +19,7 @@ class _AccountRegistState extends State<AccountRegist> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        padding: EdgeInsets.symmetric(horizontal: 10),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
         height: double.infinity,
         decoration: const BoxDecoration(
           color: Color(0xFFCAE2ED),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -15,6 +15,7 @@ class AccountRegist extends StatefulWidget {
 class _AccountRegistState extends State<AccountRegist> {
   // アカウントデータ
   AccountMst account = AccountMst.empty();
+  bool _isObscure = true;
 
   @override
   Widget build(BuildContext context) {
@@ -120,16 +121,30 @@ class _AccountRegistState extends State<AccountRegist> {
                   const SizedBox(height: 1),
                   Container(
                     color: customSwatch[50],
-                    child: TextField(
-                      decoration: const InputDecoration(
+                    child: TextFormField(
+                      obscureText: _isObscure,
+                      decoration: InputDecoration(
                         border: InputBorder.none,
-                        label: Center(
+                        label: const Center(
                           child: Text(
                             'パスワード',
                             style: TextStyle(color: Colors.grey),
                           ),
                         ),
+                        suffixIcon: IconButton(
+                          icon: Icon(_isObscure
+                              ? Icons.visibility_off
+                              : Icons.visibility),
+                          onPressed: () {
+                            setState(
+                              () {
+                                _isObscure = !_isObscure;
+                              },
+                            );
+                          },
+                        ),
                       ),
+
                       // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                       onChanged: (String value) {
                         // データを変更

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -165,7 +165,6 @@ class _AccountRegistState extends State<AccountRegist> {
                           color: Colors.grey,
                         ),
                         child: TextButton(
-                          
                           onPressed: () {},
                           child: const Text(
                             '設定',
@@ -183,7 +182,6 @@ class _AccountRegistState extends State<AccountRegist> {
                           color: Color.fromARGB(189, 3, 77, 129),
                         ),
                         child: TextButton(
-                          
                           onPressed: () {},
                           child: const Text(
                             '自動作成',

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -29,7 +29,9 @@ class _AccountRegistState extends State<AccountRegist> {
         ),
         margin: const EdgeInsets.only(top: 15),
         child: Column(children: <Widget>[
-          Row(children: <Widget>[
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop();
@@ -37,11 +39,9 @@ class _AccountRegistState extends State<AccountRegist> {
               child: const Text('✕',
                   style: TextStyle(color: customSwatch, fontSize: 20)),
             ),
-            const Expanded(child: SizedBox()),
             const Text('パスワードの登録',
                 style: TextStyle(
                     color: customSwatch, fontWeight: FontWeight.bold)),
-            const Expanded(child: SizedBox()),
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop(account);

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -32,7 +32,7 @@ class _AccountRegistState extends State<AccountRegist> {
           Row(children: <Widget>[
             TextButton(
               onPressed: () {
-                Navigator.of(context).pop(account);
+                Navigator.of(context).pop();
               },
               child: const Text('✕',
                   style: TextStyle(color: customSwatch, fontSize: 20)),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -30,92 +30,89 @@ class _AccountRegistState extends State<AccountRegist> {
         margin: const EdgeInsets.only(top: 15),
         child: Column(children: <Widget>[
           Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: const Text('✕',
-                  style: TextStyle(color: customSwatch, fontSize: 20)),
-            ),
-            const Text('パスワードの登録',
-                style: TextStyle(
-                    color: customSwatch, fontWeight: FontWeight.bold)),
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop(account);
-              },
-              child: const Text('登録', style: TextStyle(color: customSwatch)),
-            ),
-          ]),
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('✕',
+                      style: TextStyle(color: customSwatch, fontSize: 20)),
+                ),
+                const Text('パスワードの登録',
+                    style: TextStyle(
+                        color: customSwatch, fontWeight: FontWeight.bold)),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop(account);
+                  },
+                  child:
+                      const Text('登録', style: TextStyle(color: customSwatch)),
+                ),
+              ]),
           Container(
               margin: const EdgeInsets.only(
                   top: 20, left: 20, right: 20, bottom: 40),
               height: 500,
               child: SingleChildScrollView(
-                  child: Column(
-                      children: <Widget>[
-                  Container(
-                    color: customSwatch[50],
-                    child:
-                    // タイトル、ID,パスワードの入力
-                    TextField(
-                      decoration: const InputDecoration(
+                  child: Column(children: <Widget>[
+                Container(
+                  color: customSwatch[50],
+                  child:
+                      // タイトル、ID,パスワードの入力
+                      TextField(
+                    decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
                           child: Text('パスワードのタイトル'),
-                        )
-                      ),
-                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                      onChanged: (String value) {
-                        // データを変更
+                        )),
+                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                    onChanged: (String value) {
+                      // データを変更
 
-                        account.title = value;
-                      },
-                    ),
-                        ),
-                    const SizedBox(height: 1),
-                    Container(
-                      color: customSwatch[50],
-                      child:
+                      account.title = value;
+                    },
+                  ),
+                ),
+                const SizedBox(height: 1),
+                Container(
+                  color: customSwatch[50],
+                  child:
                       // タイトル、ID,パスワードの入力
                       TextField(
-                      decoration: const InputDecoration(
+                    decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
                           child: Text('アカウント・ID'),
-                        )
-                      ),
-                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                      onChanged: (String value) {
-                        // データを変更
+                        )),
+                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                    onChanged: (String value) {
+                      // データを変更
 
-                        account.accountId = value;
-                      },
-                    ),
-                    ),
-                    const SizedBox(height: 1),
-                    Container(
-                      color: customSwatch[50],
-                      child:
+                      account.accountId = value;
+                    },
+                  ),
+                ),
+                const SizedBox(height: 1),
+                Container(
+                  color: customSwatch[50],
+                  child:
                       // タイトル、ID,パスワードの入力
                       TextField(
-                      decoration: const InputDecoration(
+                    decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
                           child: Text('パスワード'),
-                        )
-                      ),
-                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                      onChanged: (String value) {
-                        // データを変更
+                        )),
+                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                    onChanged: (String value) {
+                      // データを変更
 
-                        account.password = value;
-                      },
-                    ),
-                    ),
-                  ]))),
+                      account.password = value;
+                    },
+                  ),
+                ),
+              ]))),
           Align(
               alignment: Alignment.bottomCenter,
               child: SizedBox(

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -19,119 +19,136 @@ class _AccountRegistState extends State<AccountRegist> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        height: double.infinity,
-        decoration: const BoxDecoration(
-          color: Color(0xFFCAE2ED),
-          borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(10),
-            topRight: Radius.circular(10),
-          ),
+      height: double.infinity,
+      decoration: const BoxDecoration(
+        color: Color(0xFFCAE2ED),
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(10),
         ),
-        margin: const EdgeInsets.only(top: 15),
-        child: Column(children: <Widget>[
+      ),
+      margin: const EdgeInsets.only(top: 15),
+      child: Column(
+        children: <Widget>[
           Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                  child: const Text('✕',
-                      style: TextStyle(color: customSwatch, fontSize: 20)),
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                child: const Text(
+                  '✕',
+                  style: TextStyle(color: customSwatch, fontSize: 20),
                 ),
-                const Text('パスワードの登録',
-                    style: TextStyle(
-                        color: customSwatch, fontWeight: FontWeight.bold)),
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop(account);
-                  },
-                  child:
-                      const Text('登録', style: TextStyle(color: customSwatch)),
+              ),
+              const Text(
+                'パスワードの登録',
+                style:
+                    TextStyle(color: customSwatch, fontWeight: FontWeight.bold),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop(account);
+                },
+                child: const Text(
+                  '登録',
+                  style: TextStyle(color: customSwatch),
                 ),
-              ]),
+              ),
+            ],
+          ),
           Container(
-              margin: const EdgeInsets.only(
-                  top: 20, left: 20, right: 20, bottom: 40),
-              height: 500,
-              child: SingleChildScrollView(
-                  child: Column(children: <Widget>[
-                Container(
-                  color: customSwatch[50],
-                  child:
-                      // タイトル、ID,パスワードの入力
-                      TextField(
-                    decoration: const InputDecoration(
+            margin:
+                const EdgeInsets.only(top: 20, left: 20, right: 20, bottom: 40),
+            height: 500,
+            child: SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
+                  Container(
+                    color: customSwatch[50],
+                    child: TextField(
+                      decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('パスワードのタイトル',
-                              style: TextStyle(color: Colors.grey)),
-                        )),
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
-
-                      account.title = value;
-                    },
+                          child: Text(
+                            'パスワードのタイトル',
+                            style: TextStyle(color: Colors.grey),
+                          ),
+                        ),
+                      ),
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
+                        account.title = value;
+                      },
+                    ),
                   ),
-                ),
-                const SizedBox(height: 1),
-                Container(
-                  color: customSwatch[50],
-                  child:
-                      // タイトル、ID,パスワードの入力
-                      TextField(
-                    decoration: const InputDecoration(
+                  const SizedBox(height: 1),
+                  Container(
+                    color: customSwatch[50],
+                    child: TextField(
+                      decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('アカウント・ID',
-                              style: TextStyle(color: Colors.grey)),
-                        )),
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
-
-                      account.accountId = value;
-                    },
+                          child: Text(
+                            'アカウント・ID',
+                            style: TextStyle(color: Colors.grey),
+                          ),
+                        ),
+                      ),
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
+                        account.accountId = value;
+                      },
+                    ),
                   ),
-                ),
-                const SizedBox(height: 1),
-                Container(
-                  color: customSwatch[50],
-                  child:
-                      // タイトル、ID,パスワードの入力
-                      TextField(
-                    decoration: const InputDecoration(
+                  const SizedBox(height: 1),
+                  Container(
+                    color: customSwatch[50],
+                    child: TextField(
+                      decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('パスワード',
-                              style: TextStyle(color: Colors.grey)),
-                        )),
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
-
-                      account.password = value;
-                    },
+                          child: Text(
+                            'パスワード',
+                            style: TextStyle(color: Colors.grey),
+                          ),
+                        ),
+                      ),
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
+                        account.password = value;
+                      },
+                    ),
                   ),
-                ),
-              ]))),
+                ],
+              ),
+            ),
+          ),
           Align(
-              alignment: Alignment.bottomCenter,
-              child: SizedBox(
-                // 横幅いっぱいに広げる
-                width: double.infinity,
-                // リスト追加ボタン
-                child: ElevatedButton(
-                  onPressed: () {
-                    // "pop"で前の画面に戻る
-                    // "pop"の引数から前の画面にデータを渡す
-                    Navigator.of(context).pop(account);
-                  },
-                  child: const Text('パスワード登録',
-                      style: TextStyle(color: Colors.white)),
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              // 横幅いっぱいに広げる
+              width: double.infinity,
+              // リスト追加ボタン
+              child: ElevatedButton(
+                onPressed: () {
+                  // "pop"で前の画面に戻る
+                  // "pop"の引数から前の画面にデータを渡す
+                  Navigator.of(context).pop(account);
+                },
+                child: const Text(
+                  'パスワード登録',
+                  style: TextStyle(color: Colors.white),
                 ),
-              )),
-        ]));
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -204,6 +204,24 @@ class _AccountRegistState extends State<AccountRegist> {
                       onPressed: () {},
                     ),
                   ),
+                  const SizedBox(
+                    height: 1,
+                  ),
+                  Container(
+                    color: customSwatch[50],
+                    child: TextField(
+                      decoration: const InputDecoration(
+                        border: InputBorder.none,
+                        label: Center(
+                          child: Text(
+                            'ログイン画面のURL',
+                            style: TextStyle(color: Colors.grey),
+                          ),
+                        ),
+                      ),
+                      onChanged: (String value) {},
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -53,15 +53,16 @@ class _AccountRegistState extends State<AccountRegist> {
               margin: const EdgeInsets.only(
                   top: 20, left: 20, right: 20, bottom: 40),
               height: 500,
-              color: customSwatch[50],
               child: SingleChildScrollView(
                   child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                    const SizedBox(height: 8),
+                  Container(
+                    color: customSwatch[50],
+                    child:
                     // タイトル、ID,パスワードの入力
                     TextField(
                       decoration: const InputDecoration(
+                        border: InputBorder.none,
                         label: Center(
                           child: Text('パスワードのタイトル'),
                         )
@@ -73,8 +74,15 @@ class _AccountRegistState extends State<AccountRegist> {
                         account.title = value;
                       },
                     ),
-                    TextField(
+                        ),
+                    const SizedBox(height: 1),
+                    Container(
+                      color: customSwatch[50],
+                      child:
+                      // タイトル、ID,パスワードの入力
+                      TextField(
                       decoration: const InputDecoration(
+                        border: InputBorder.none,
                         label: Center(
                           child: Text('アカウント・ID'),
                         )
@@ -86,8 +94,15 @@ class _AccountRegistState extends State<AccountRegist> {
                         account.accountId = value;
                       },
                     ),
-                    TextField(
+                    ),
+                    const SizedBox(height: 1),
+                    Container(
+                      color: customSwatch[50],
+                      child:
+                      // タイトル、ID,パスワードの入力
+                      TextField(
                       decoration: const InputDecoration(
+                        border: InputBorder.none,
                         label: Center(
                           child: Text('パスワード'),
                         )
@@ -99,8 +114,7 @@ class _AccountRegistState extends State<AccountRegist> {
                         account.password = value;
                       },
                     ),
-
-                    const SizedBox(height: 8),
+                    ),
                   ]))),
           Align(
               alignment: Alignment.bottomCenter,

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -35,10 +35,13 @@ class _AccountRegistState extends State<AccountRegist> {
               onPressed: () {
                 Navigator.of(context).pop(account);
               },
-              child: const Text('✕', style: TextStyle(color: customSwatch,fontSize: 20)),
+              child: const Text('✕',
+                  style: TextStyle(color: customSwatch, fontSize: 20)),
             ),
             const Expanded(child: SizedBox()),
-            const Text('パスワードの登録', style: TextStyle(color: customSwatch,fontWeight: FontWeight.bold)),
+            const Text('パスワードの登録',
+                style: TextStyle(
+                    color: customSwatch, fontWeight: FontWeight.bold)),
             const Expanded(child: SizedBox()),
             TextButton(
               onPressed: () {

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -16,21 +16,17 @@ class _AccountRegistState extends State<AccountRegist> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          title: const Text("テスト"),
-          actions: <Widget>[
-            IconButton(
-              icon: const Icon(Icons.back_hand),
-              tooltip: '戻る',
-              onPressed: () {
-                // "pop"で前の画面に戻る
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
+    return Container(
+      height: double.infinity,
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(10),
         ),
-        body: Container(
+      ),
+      margin: const EdgeInsets.only(top: 10),
+      child:  Container(
             // 余白を付ける
             padding: const EdgeInsets.all(64),
             child: Column(

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -61,6 +61,11 @@ class _AccountRegistState extends State<AccountRegist> {
                     const SizedBox(height: 8),
                     // タイトル、ID,パスワードの入力
                     TextField(
+                      decoration: const InputDecoration(
+                        label: Center(
+                          child: Text('パスワードのタイトル'),
+                        )
+                      ),
                       // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                       onChanged: (String value) {
                         // データを変更
@@ -69,6 +74,11 @@ class _AccountRegistState extends State<AccountRegist> {
                       },
                     ),
                     TextField(
+                      decoration: const InputDecoration(
+                        label: Center(
+                          child: Text('アカウント・ID'),
+                        )
+                      ),
                       // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                       onChanged: (String value) {
                         // データを変更
@@ -77,6 +87,11 @@ class _AccountRegistState extends State<AccountRegist> {
                       },
                     ),
                     TextField(
+                      decoration: const InputDecoration(
+                        label: Center(
+                          child: Text('パスワード'),
+                        )
+                      ),
                       // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                       onChanged: (String value) {
                         // データを変更

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -64,7 +64,8 @@ class _AccountRegistState extends State<AccountRegist> {
                     decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('パスワードのタイトル'),
+                          child: Text('パスワードのタイトル',
+                              style: TextStyle(color: Colors.grey)),
                         )),
                     // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                     onChanged: (String value) {
@@ -83,7 +84,8 @@ class _AccountRegistState extends State<AccountRegist> {
                     decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('アカウント・ID'),
+                          child: Text('アカウント・ID',
+                              style: TextStyle(color: Colors.grey)),
                         )),
                     // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                     onChanged: (String value) {
@@ -102,7 +104,8 @@ class _AccountRegistState extends State<AccountRegist> {
                     decoration: const InputDecoration(
                         border: InputBorder.none,
                         label: Center(
-                          child: Text('パスワード'),
+                          child: Text('パスワード',
+                              style: TextStyle(color: Colors.grey)),
                         )),
                     // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
                     onChanged: (String value) {

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:passwordmanagerapp/account_mst.dart';
 
+import 'main.dart';
+
 // リスト一覧画面用Widget
 class AccountRegist extends StatefulWidget {
   const AccountRegist({super.key});
@@ -26,68 +28,87 @@ class _AccountRegistState extends State<AccountRegist> {
           ),
         ),
         margin: const EdgeInsets.only(top: 10),
-        child: Container(
-            // 余白を付ける
-            padding: const EdgeInsets.all(64),
-            child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const SizedBox(height: 8),
-                  // タイトル、ID,パスワードの入力
-                  TextField(
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
+        child: Column(children: <Widget>[
+          Row(children: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(account);
+              },
+              child: const Text('✕', style: TextStyle(color: customSwatch,fontSize: 20)),
+            ),
+            const Expanded(child: SizedBox()),
+            const Text('パスワードの登録', style: TextStyle(color: customSwatch,fontWeight: FontWeight.bold)),
+            const Expanded(child: SizedBox()),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(account);
+              },
+              child: const Text('登録', style: TextStyle(color: customSwatch)),
+            ),
+          ]),
+          Container(
+              // 余白を付ける
+              padding: const EdgeInsets.all(64),
+              child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    const SizedBox(height: 8),
+                    // タイトル、ID,パスワードの入力
+                    TextField(
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
 
-                      account.title = value;
-                    },
-                  ),
-                  TextField(
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
-
-                      account.accountId = value;
-                    },
-                  ),
-                  TextField(
-                    // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                    onChanged: (String value) {
-                      // データを変更
-
-                      account.password = value;
-                    },
-                  ),
-
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    // 横幅いっぱいに広げる
-                    width: double.infinity,
-                    // リスト追加ボタン
-                    child: ElevatedButton(
-                      onPressed: () {
-                        // "pop"で前の画面に戻る
-                        // "pop"の引数から前の画面にデータを渡す
-                        Navigator.of(context).pop(account);
+                        account.title = value;
                       },
-                      child: const Text('パスワード登録',
-                          style: TextStyle(color: Colors.white)),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    // 横幅いっぱいに広げる
-                    width: double.infinity,
-                    // キャンセルボタン
-                    child: TextButton(
-                      // ボタンをクリックした時の処理
-                      onPressed: () {
-                        // "pop"で前の画面に戻る
-                        Navigator.of(context).pop();
+                    TextField(
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
+
+                        account.accountId = value;
                       },
-                      child: const Text('キャンセル'),
                     ),
-                  ),
-                ])));
+                    TextField(
+                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                      onChanged: (String value) {
+                        // データを変更
+
+                        account.password = value;
+                      },
+                    ),
+
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      // 横幅いっぱいに広げる
+                      width: double.infinity,
+                      // リスト追加ボタン
+                      child: ElevatedButton(
+                        onPressed: () {
+                          // "pop"で前の画面に戻る
+                          // "pop"の引数から前の画面にデータを渡す
+                          Navigator.of(context).pop(account);
+                        },
+                        child: const Text('パスワード登録',
+                            style: TextStyle(color: Colors.white)),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      // 横幅いっぱいに広げる
+                      width: double.infinity,
+                      // キャンセルボタン
+                      child: TextButton(
+                        // ボタンをクリックした時の処理
+                        onPressed: () {
+                          // "pop"で前の画面に戻る
+                          Navigator.of(context).pop();
+                        },
+                        child: const Text('キャンセル'),
+                      ),
+                    ),
+                  ]))
+        ]));
   }
 }

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -17,16 +17,16 @@ class _AccountRegistState extends State<AccountRegist> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: double.infinity,
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(10),
-          topRight: Radius.circular(10),
+        height: double.infinity,
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(10),
+            topRight: Radius.circular(10),
+          ),
         ),
-      ),
-      margin: const EdgeInsets.only(top: 10),
-      child:  Container(
+        margin: const EdgeInsets.only(top: 10),
+        child: Container(
             // 余白を付ける
             padding: const EdgeInsets.all(64),
             child: Column(

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -120,38 +120,81 @@ class _AccountRegistState extends State<AccountRegist> {
                     ),
                   ),
                   const SizedBox(height: 1),
-                  Container(
-                    color: customSwatch[50],
-                    child: TextFormField(
-                      obscureText: _isObscure,
-                      decoration: InputDecoration(
-                        border: InputBorder.none,
-                        label: const Center(
-                          child: Text(
-                            'パスワード',
-                            style: TextStyle(color: Colors.grey),
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Container(
+                          color: customSwatch[50],
+                          child: TextFormField(
+                            obscureText: _isObscure,
+                            decoration: InputDecoration(
+                              border: InputBorder.none,
+                              label: const Center(
+                                child: Text(
+                                  'パスワード',
+                                  style: TextStyle(color: Colors.grey),
+                                ),
+                              ),
+                              suffixIcon: IconButton(
+                                icon: Icon(_isObscure
+                                    ? Icons.visibility_off
+                                    : Icons.visibility),
+                                onPressed: () {
+                                  setState(
+                                    () {
+                                      _isObscure = !_isObscure;
+                                    },
+                                  );
+                                },
+                              ),
+                            ),
+
+                            // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
+                            onChanged: (String value) {
+                              // データを変更
+                              account.password = value;
+                            },
                           ),
                         ),
-                        suffixIcon: IconButton(
-                          icon: Icon(_isObscure
-                              ? Icons.visibility_off
-                              : Icons.visibility),
-                          onPressed: () {
-                            setState(
-                              () {
-                                _isObscure = !_isObscure;
-                              },
-                            );
-                          },
+                      ),
+                      const SizedBox(width: 1),
+                      Container(
+                        width: 50,
+                        height: 50,
+                        decoration:const BoxDecoration(
+                          color: Colors.grey,
+                        ),
+                        child: TextButton(
+                          
+                          onPressed: () {},
+                          child: const Text(
+                            '設定',
+                            style: TextStyle(
+                              color: Colors.black,
+                              fontSize: 10,
+                              ),
+                          ),
                         ),
                       ),
-
-                      // 入力されたテキストの値を受け取る（valueが入力されたテキスト）
-                      onChanged: (String value) {
-                        // データを変更
-                        account.password = value;
-                      },
-                    ),
+                      Container(
+                        width: 50,
+                        height: 50,
+                        decoration:const BoxDecoration(
+                          color: Color.fromARGB(189, 3, 77, 129),
+                        ),
+                        child: TextButton(
+                          
+                          onPressed: () {},
+                          child: const Text(
+                            '自動作成',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 8.5,
+                              ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -196,6 +196,16 @@ class _AccountRegistState extends State<AccountRegist> {
                       ),
                     ],
                   ),
+                  const SizedBox(height: 1),
+                  Container(
+                    color: customSwatch[50],
+                    height: 50,
+                    width: double.infinity,
+                    child: TextButton(
+                      child: const Text('すべて'),
+                      onPressed: () {},
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -50,13 +50,14 @@ class _AccountRegistState extends State<AccountRegist> {
             ),
           ]),
           Container(
-              margin: const EdgeInsets.only(top: 20, left: 20, right: 20, bottom: 40),
+              margin: const EdgeInsets.only(
+                  top: 20, left: 20, right: 20, bottom: 40),
               height: 500,
               color: customSwatch[50],
               child: SingleChildScrollView(
-              child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
+                  child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
                     const SizedBox(height: 8),
                     // タイトル、ID,パスワードの入力
                     TextField(
@@ -85,28 +86,23 @@ class _AccountRegistState extends State<AccountRegist> {
                     ),
 
                     const SizedBox(height: 8),
-                  ]
-                )
-            )),
+                  ]))),
           Align(
-            alignment: Alignment.bottomCenter,
-            child: SizedBox(
-              // 横幅いっぱいに広げる
-              width: double.infinity,
-              // リスト追加ボタン
-              child: ElevatedButton(
-                onPressed: () {
-                  // "pop"で前の画面に戻る
-                  // "pop"の引数から前の画面にデータを渡す
-                  Navigator.of(context).pop(account);
-                },
-                child: const Text('パスワード登録',
-                    style: TextStyle(color: Colors.white)),
-              ),
-            )
-          ),
-        ]
-      )
-    );
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                // 横幅いっぱいに広げる
+                width: double.infinity,
+                // リスト追加ボタン
+                child: ElevatedButton(
+                  onPressed: () {
+                    // "pop"で前の画面に戻る
+                    // "pop"の引数から前の画面にデータを渡す
+                    Navigator.of(context).pop(account);
+                  },
+                  child: const Text('パスワード登録',
+                      style: TextStyle(color: Colors.white)),
+                ),
+              )),
+        ]));
   }
 }

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -19,15 +19,16 @@ class _AccountRegistState extends State<AccountRegist> {
   @override
   Widget build(BuildContext context) {
     return Container(
+        padding: EdgeInsets.symmetric(horizontal: 10),
         height: double.infinity,
         decoration: const BoxDecoration(
-          color: Colors.white,
+          color: Color(0xFFCAE2ED),
           borderRadius: BorderRadius.only(
             topLeft: Radius.circular(10),
             topRight: Radius.circular(10),
           ),
         ),
-        margin: const EdgeInsets.only(top: 10),
+        margin: const EdgeInsets.only(top: 15),
         child: Column(children: <Widget>[
           Row(children: <Widget>[
             TextButton(
@@ -47,6 +48,8 @@ class _AccountRegistState extends State<AccountRegist> {
             ),
           ]),
           Container(
+              margin: const EdgeInsets.only(top: 20),
+              color: customSwatch[50],
               // 余白を付ける
               padding: const EdgeInsets.all(64),
               child: Column(

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -161,7 +161,7 @@ class _AccountRegistState extends State<AccountRegist> {
                       Container(
                         width: 50,
                         height: 50,
-                        decoration:const BoxDecoration(
+                        decoration: const BoxDecoration(
                           color: Colors.grey,
                         ),
                         child: TextButton(
@@ -171,14 +171,14 @@ class _AccountRegistState extends State<AccountRegist> {
                             style: TextStyle(
                               color: Colors.black,
                               fontSize: 10,
-                              ),
+                            ),
                           ),
                         ),
                       ),
                       Container(
                         width: 50,
                         height: 50,
-                        decoration:const BoxDecoration(
+                        decoration: const BoxDecoration(
                           color: Color.fromARGB(189, 3, 77, 129),
                         ),
                         child: TextButton(
@@ -188,7 +188,7 @@ class _AccountRegistState extends State<AccountRegist> {
                             style: TextStyle(
                               color: Colors.white,
                               fontSize: 8.5,
-                              ),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/account_regist.dart
+++ b/lib/account_regist.dart
@@ -19,7 +19,6 @@ class _AccountRegistState extends State<AccountRegist> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10),
         height: double.infinity,
         decoration: const BoxDecoration(
           color: Color(0xFFCAE2ED),
@@ -51,10 +50,10 @@ class _AccountRegistState extends State<AccountRegist> {
             ),
           ]),
           Container(
-              margin: const EdgeInsets.only(top: 20),
+              margin: const EdgeInsets.only(top: 20, left: 20, right: 20, bottom: 40),
+              height: 500,
               color: customSwatch[50],
-              // 余白を付ける
-              padding: const EdgeInsets.all(64),
+              child: SingleChildScrollView(
               child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
@@ -86,35 +85,28 @@ class _AccountRegistState extends State<AccountRegist> {
                     ),
 
                     const SizedBox(height: 8),
-                    SizedBox(
-                      // 横幅いっぱいに広げる
-                      width: double.infinity,
-                      // リスト追加ボタン
-                      child: ElevatedButton(
-                        onPressed: () {
-                          // "pop"で前の画面に戻る
-                          // "pop"の引数から前の画面にデータを渡す
-                          Navigator.of(context).pop(account);
-                        },
-                        child: const Text('パスワード登録',
-                            style: TextStyle(color: Colors.white)),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    SizedBox(
-                      // 横幅いっぱいに広げる
-                      width: double.infinity,
-                      // キャンセルボタン
-                      child: TextButton(
-                        // ボタンをクリックした時の処理
-                        onPressed: () {
-                          // "pop"で前の画面に戻る
-                          Navigator.of(context).pop();
-                        },
-                        child: const Text('キャンセル'),
-                      ),
-                    ),
-                  ]))
-        ]));
+                  ]
+                )
+            )),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              // 横幅いっぱいに広げる
+              width: double.infinity,
+              // リスト追加ボタン
+              child: ElevatedButton(
+                onPressed: () {
+                  // "pop"で前の画面に戻る
+                  // "pop"の引数から前の画面にデータを渡す
+                  Navigator.of(context).pop(account);
+                },
+                child: const Text('パスワード登録',
+                    style: TextStyle(color: Colors.white)),
+              ),
+            )
+          ),
+        ]
+      )
+    );
   }
 }


### PR DESCRIPTION
## 対応概要
- 主にアカウント登録画面のデザインを修正しました。
- ten,shinの共同作業により作成を行いました。
- 既存アプリの登録画面になるべく近づけるように作成しました。
- 機能的な追加は行っていません。

## 修正前
![image](https://github.com/ten-revengineer/PasswordManagerApp/assets/124700571/66261252-3a44-4466-9a2e-900c560f3856)

## 修正後
![image](https://github.com/ten-revengineer/PasswordManagerApp/assets/124700571/76a31f85-ccd9-4a02-9097-7674e22e1029)

## 仕様画面(既存アプリの画面)
![リベンジニア_アカウント登録画面](https://github.com/ten-revengineer/PasswordManagerApp/assets/124700571/3f16d6bb-cefd-470a-adc1-67d8f5b02bbe)
